### PR TITLE
[마이페이지] 초기화면 > 주문 내역(요약)

### DIFF
--- a/src/components/myPage/main/OrderSummary.js
+++ b/src/components/myPage/main/OrderSummary.js
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
+import { useHistory } from 'react-router-dom';
 import { getProfileOrdersSummaryStatus } from '../../../api/order';
 
 const OrderSummary = () => {
+  const history = useHistory();
   const [summary, setSummary] = useState({
     depositWaitCnt: 0,
     payDoneCnt: 0,
@@ -20,13 +22,17 @@ const OrderSummary = () => {
 
   useEffect(() => {
     getProfileOrdersSummaryStatus().then((res) => {
-      console.log('res.data:', res.data);
       setSummary(res.data);
     });
   }, []);
 
   const hasOrder = (statusCount) => {
     return statusCount > 0 ? 'on' : '';
+  };
+
+  const onClickOrderStatus = (e, orderRequestType) => {
+    e.preventDefault();
+    history.push('my-page/order-list');
   };
 
   return (
@@ -44,7 +50,7 @@ const OrderSummary = () => {
               {/* 1건 이상 부터 class: on 추가 */}
               <div className="ship_box">
                 <span className="ico_txt">입금대기</span>
-                <a className="val_txt">
+                <a href="#" className="val_txt" onClick={(e) => onClickOrderStatus(e, 'DEPOSIT_WAIT')}>
                   <span className="val">{summary.depositWaitCnt}</span>
                   <span>건</span>
                 </a>
@@ -53,7 +59,7 @@ const OrderSummary = () => {
             <li className={`step_2 ${hasOrder(summary.payDoneCnt)}`}>
               <div className="ship_box">
                 <span className="ico_txt">결제완료</span>
-                <a className="val_txt">
+                <a href="#" className="val_txt" onClick={(e) => onClickOrderStatus(e, 'PAY_DONE')}>
                   <span className="val">{summary.payDoneCnt}</span>
                   <span>건</span>
                 </a>
@@ -62,7 +68,11 @@ const OrderSummary = () => {
             <li className={`step_3 ${hasOrder(summary.deliveryPrepareCnt + summary.productPrepareCnt)}`}>
               <div className="ship_box">
                 <span className="ico_txt">배송준비</span>
-                <a className="val_txt">
+                <a
+                  href="#"
+                  className="val_txt"
+                  onClick={(e) => onClickOrderStatus(e, 'PRODUCT_PREPARE,DELIVERY_PREPARE')}
+                >
                   <span className="val">{summary.deliveryPrepareCnt + summary.productPrepareCnt}</span>
                   <span>건</span>
                 </a>
@@ -71,7 +81,7 @@ const OrderSummary = () => {
             <li className={`step_4 ${hasOrder(summary.deliveryIngCnt)}`}>
               <div className="ship_box">
                 <span className="ico_txt">배송중</span>
-                <a className="val_txt">
+                <a href="#" className="val_txt" onClick={(e) => onClickOrderStatus(e, 'DELIVERY_ING')}>
                   <span className="val">{summary.deliveryIngCnt}</span>
                   <span>건</span>
                 </a>
@@ -80,7 +90,7 @@ const OrderSummary = () => {
             <li className={`step_5 ${hasOrder(summary.deliveryDoneCnt)}`}>
               <div className="ship_box">
                 <span className="ico_txt">배송완료</span>
-                <a className="val_txt">
+                <a href="#" className="val_txt" onClick={(e) => onClickOrderStatus(e, 'DELIVERY_DONE')}>
                   <span className="val">{summary.deliveryDoneCnt}</span>
                   <span>건</span>
                 </a>
@@ -91,7 +101,7 @@ const OrderSummary = () => {
         <div className="my_claim">
           <p className={`txt cancel ${hasOrder(summary.cancelProcessingCnt + summary.cancelDoneCnt)}`}>
             주문 취소{' '}
-            <a title="주문 취소 건">
+            <a href="#" title="주문 취소 건" onClick={(e) => onClickOrderStatus(e, 'DELIVERY_DONE')}>
               <strong className="val_txt">
                 <span className="val">{summary.cancelProcessingCnt + summary.cancelDoneCnt}</span> 건
               </strong>
@@ -106,7 +116,7 @@ const OrderSummary = () => {
             )}`}
           >
             교환 반품{' '}
-            <a title="교환 반품 건">
+            <a href="#" title="교환 반품 건" onClick={(e) => onClickOrderStatus(e, 'CANCEL_PROCESSING,CANCEL_DONE')}>
               <strong className="val_txt">
                 <span className="val">
                   {summary.exchangeDoneCnt +

--- a/src/components/myPage/main/OrderSummary.js
+++ b/src/components/myPage/main/OrderSummary.js
@@ -30,9 +30,9 @@ const OrderSummary = () => {
     return statusCount > 0 ? 'on' : '';
   };
 
-  const onClickOrderStatus = (e, orderRequestType) => {
+  const onClickOrderStatus = (e, orderRequestTypes) => {
     e.preventDefault();
-    history.push('my-page/order-list');
+    history.push(`my-page/order-list?orderRequestTypes=${orderRequestTypes}`);
   };
 
   return (
@@ -101,7 +101,7 @@ const OrderSummary = () => {
         <div className="my_claim">
           <p className={`txt cancel ${hasOrder(summary.cancelProcessingCnt + summary.cancelDoneCnt)}`}>
             주문 취소{' '}
-            <a href="#" title="주문 취소 건" onClick={(e) => onClickOrderStatus(e, 'DELIVERY_DONE')}>
+            <a href="#" title="주문 취소 건" onClick={(e) => onClickOrderStatus(e, 'CANCEL_PROCESSING,CANCEL_DONE')}>
               <strong className="val_txt">
                 <span className="val">{summary.cancelProcessingCnt + summary.cancelDoneCnt}</span> 건
               </strong>
@@ -116,7 +116,7 @@ const OrderSummary = () => {
             )}`}
           >
             교환 반품{' '}
-            <a href="#" title="교환 반품 건" onClick={(e) => onClickOrderStatus(e, 'CANCEL_PROCESSING,CANCEL_DONE')}>
+            <a title="교환 반품 건">
               <strong className="val_txt">
                 <span className="val">
                   {summary.exchangeDoneCnt +

--- a/src/components/myPage/main/OrderSummary.js
+++ b/src/components/myPage/main/OrderSummary.js
@@ -1,4 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { getProfileOrdersSummaryStatus } from '../../../api/order';
+
 const OrderSummary = () => {
+  const [summary, setSummary] = useState({
+    depositWaitCnt: 0,
+    payDoneCnt: 0,
+    productPrepareCnt: 0,
+    deliveryPrepareCnt: 0,
+    deliveryIngCnt: 0,
+    deliveryDoneCnt: 0,
+    buyConfirmCnt: 0,
+    cancelDoneCnt: 0,
+    returnDoneCnt: 0,
+    exchangeDoneCnt: 0,
+    cancelProcessingCnt: 0,
+    returnProcessingCnt: 0,
+    exchangeProcessingCnt: 0,
+  });
+
+  useEffect(() => {
+    getProfileOrdersSummaryStatus().then((res) => {
+      console.log('res.data:', res.data);
+      setSummary(res.data);
+    });
+  }, []);
+
+  const hasOrder = (statusCount) => {
+    return statusCount > 0 ? 'on' : '';
+  };
+
   return (
     <div className="cont history_order">
       <div className="tit_head">
@@ -10,48 +40,48 @@ const OrderSummary = () => {
       <div className="history_inner">
         <div className="my_order">
           <ul className="order_list">
-            <li className="step_1 on">
+            <li className={`step_1 ${hasOrder(summary.depositWaitCnt)}`}>
               {/* 1건 이상 부터 class: on 추가 */}
               <div className="ship_box">
                 <span className="ico_txt">입금대기</span>
                 <a className="val_txt">
-                  <span className="val">4</span>
+                  <span className="val">{summary.depositWaitCnt}</span>
                   <span>건</span>
                 </a>
               </div>
             </li>
-            <li className="step_2">
+            <li className={`step_2 ${hasOrder(summary.payDoneCnt)}`}>
               <div className="ship_box">
                 <span className="ico_txt">결제완료</span>
                 <a className="val_txt">
-                  <span className="val">0</span>
+                  <span className="val">{summary.payDoneCnt}</span>
                   <span>건</span>
                 </a>
               </div>
             </li>
-            <li className="step_3">
+            <li className={`step_3 ${hasOrder(summary.deliveryPrepareCnt + summary.productPrepareCnt)}`}>
               <div className="ship_box">
                 <span className="ico_txt">배송준비</span>
                 <a className="val_txt">
-                  <span className="val">0</span>
+                  <span className="val">{summary.deliveryPrepareCnt + summary.productPrepareCnt}</span>
                   <span>건</span>
                 </a>
               </div>
             </li>
-            <li className="step_4 on">
+            <li className={`step_4 ${hasOrder(summary.deliveryIngCnt)}`}>
               <div className="ship_box">
                 <span className="ico_txt">배송중</span>
                 <a className="val_txt">
-                  <span className="val">1</span>
+                  <span className="val">{summary.deliveryIngCnt}</span>
                   <span>건</span>
                 </a>
               </div>
             </li>
-            <li className="step_5 on">
+            <li className={`step_5 ${hasOrder(summary.deliveryDoneCnt)}`}>
               <div className="ship_box">
                 <span className="ico_txt">배송완료</span>
                 <a className="val_txt">
-                  <span className="val">1</span>
+                  <span className="val">{summary.deliveryDoneCnt}</span>
                   <span>건</span>
                 </a>
               </div>
@@ -59,19 +89,32 @@ const OrderSummary = () => {
           </ul>
         </div>
         <div className="my_claim">
-          <p className="txt cancel on">
+          <p className={`txt cancel ${hasOrder(summary.cancelProcessingCnt + summary.cancelDoneCnt)}`}>
             주문 취소{' '}
             <a title="주문 취소 건">
               <strong className="val_txt">
-                <span className="val">4</span> 건
+                <span className="val">{summary.cancelProcessingCnt + summary.cancelDoneCnt}</span> 건
               </strong>
             </a>
           </p>
-          <p className="txt return">
+          <p
+            className={`txt return ${hasOrder(
+              summary.exchangeDoneCnt +
+                summary.returnDoneCnt +
+                summary.returnProcessingCnt +
+                summary.returnProcessingCnt,
+            )}`}
+          >
             교환 반품{' '}
             <a title="교환 반품 건">
               <strong className="val_txt">
-                <span className="val">0</span> 건
+                <span className="val">
+                  {summary.exchangeDoneCnt +
+                    summary.returnDoneCnt +
+                    summary.returnProcessingCnt +
+                    summary.returnProcessingCnt}
+                </span>{' '}
+                건
               </strong>
             </a>
           </p>

--- a/src/pages/mypage/orderList.js
+++ b/src/pages/mypage/orderList.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import { addMonth, changeDateFormat } from '../../utils/dateFormat';
 import { Link } from 'react-router-dom';
 import { getProfileOrders, getProfileOrdersSummaryStatus } from '../../api/order';
+import { useQuery } from '../../hooks';
 
 import OrderStatusSummary from '../../components/myPage/order/OrderStatusSummary';
 import DateBox from '../../components/myPage/DateBox';
@@ -20,6 +21,7 @@ import '../../assets/scss/contents.scss';
 import '../../assets/scss/mypage.scss';
 
 export default function OrderList() {
+  const query = useQuery();
   const [summary, setSummary] = useState({
     depositWaitCnt: 0,
     payDoneCnt: 0,
@@ -51,12 +53,13 @@ export default function OrderList() {
   }, []);
 
   useEffect(() => {
+    const orderRequestTypesQuery = query.get('orderRequestTypes');
     search({
       startDate: new Date(addMonth(new Date(), -3)),
       endDate: new Date(),
       pageNumber: 1,
       pageSize: 10,
-      orderRequestTypes: '',
+      orderRequestTypes: orderRequestTypesQuery ? orderRequestTypesQuery : '',
     });
   }, []);
 


### PR DESCRIPTION
- 주문 요약 완료
  - 주문 상태별 카운트
  - 주문 상태 카운트 UI 클릭 시 주문내역화면으로 이동
- 스타일 정리 필요

@kjkandrea  주문요약쪽 완료되었습니다. 스타일은 마지막에 한꺼번에 잡는게 좋을거 같애서 안잡았어용
 