### PR TITLE
[QA] 카테고리에 Back Forward Cache 적용

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -194,6 +194,8 @@ const App = (props) => {
       if (action === 'POP' && state && state.scroll) {
         const { x, y, attempt = MAX_SYNC_ATTEMPT } = state.scroll;
         syncScroll(x, y, attempt);
+      } else {
+        window.scrollTo(0, 0);
       }
     });
     return unlisten;


### PR DESCRIPTION
정확히는 이전 페이지 스크롤 유지 적용  
spa에서는 bfcache가 적용되지 않기 때문에 history, location 정보로 스크롤 정보 저장했다가 위치 찾아가게끔 적용  
참조: https://godsenal.com/posts/React-router%EC%99%80-scroll-restoration-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0/