### PR TITLE
Add 비회원 구매 카트 : 카트 진입/수량 변경때 구매 불가능한 상품으로 인해, 구매 불가시 알림 표출 및 데이터 보정

### DIFF
--- a/src/components/cart/tableParticals/ProductList.js
+++ b/src/components/cart/tableParticals/ProductList.js
@@ -19,15 +19,15 @@ const ProductList = ({ products, setProducts, setBeforeCountProducts, checkedInd
 
   const changeQuantity = (productIndex, value) => {
     const newProducts = [...products];
-    setBeforeCountProducts(JSON.parse(JSON.stringify(newProducts))); // 비회
-                                                                    // 장바구니에서
-                                                                    // 재고 소진등
-                                                                    // 문제로 해당
-                                                                    // 상품이
-                                                                    // 장바구니에서
-                                                                    // 사라지는 문제
-                                                                    // 보정하기
-                                                                    // 위함..
+    setBeforeCountProducts(JSON.parse(JSON.stringify(newProducts))); // 비회원
+    // 장바구니에서
+    // 재고 소진등
+    // 문제로 해당
+    // 상품이
+    // 장바구니에서
+    // 사라지는 문제
+    // 보정하기
+    // 위함..
 
     newProducts[productIndex].orderCnt += value;
     newProducts[productIndex].update = true;

--- a/src/components/cart/tableParticals/ProductList.js
+++ b/src/components/cart/tableParticals/ProductList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { toCurrencyString } from '../../../utils/unit';
 
-const ProductList = ({ products, setProducts, checkedIndexes, setCheckedIndexes, deleteItem }) => {
+const ProductList = ({ products, setProducts, setBeforeCountProducts, checkedIndexes, setCheckedIndexes, deleteItem }) => {
   const onCheck = (event, index) => {
     const { checked } = event.currentTarget;
 
@@ -9,7 +9,8 @@ const ProductList = ({ products, setProducts, checkedIndexes, setCheckedIndexes,
       const newCheckedIndexes = [...checkedIndexes, index];
 
       setCheckedIndexes(newCheckedIndexes);
-    } else {
+    }
+    else {
       const newCheckedIndexes = checkedIndexes.filter((v) => v !== index);
 
       setCheckedIndexes(newCheckedIndexes);
@@ -18,6 +19,15 @@ const ProductList = ({ products, setProducts, checkedIndexes, setCheckedIndexes,
 
   const changeQuantity = (productIndex, value) => {
     const newProducts = [...products];
+    setBeforeCountProducts(JSON.parse(JSON.stringify(newProducts))); // 비회
+                                                                    // 장바구니에서
+                                                                    // 재고 소진등
+                                                                    // 문제로 해당
+                                                                    // 상품이
+                                                                    // 장바구니에서
+                                                                    // 사라지는 문제
+                                                                    // 보정하기
+                                                                    // 위함..
 
     newProducts[productIndex].orderCnt += value;
     newProducts[productIndex].update = true;

--- a/src/components/common/LayerPopup.js
+++ b/src/components/common/LayerPopup.js
@@ -31,7 +31,6 @@ const LayerPopup = ({ children, onClose, className, popContClassName = '', popCo
   // ux-common.js 내 popScrollChk 함수 참조
   const _getPopupConstStyle = () => {
     const style = !!popContStyle ? {...popContStyle} : {};
-
     const scrollChild = children?.filter(child => child?.props?.className.includes('pop_cont_scroll'))[0];
     let $scroll = scrollChild?.ref;
 

--- a/src/pages/order/Cart.js
+++ b/src/pages/order/Cart.js
@@ -51,6 +51,16 @@ const Cart = ({ location }) => {
   // state
   const [wait, setWait] = useState(false);
   const [products, setProducts] = useState([]);
+  const [beforeCountProducts, setBeforeCountProducts] = useState([]); // 비회원
+                                                                      // 장바구니에서
+                                                                      // 재고 소진등
+                                                                      // 문제로 해당
+                                                                      // 상품이
+                                                                      // 장바구니에서
+                                                                      // 사라지는
+                                                                      // 문제
+                                                                      // 보정하기
+                                                                      // 위한 데이터
   const putProducts = useMemo(
     () =>
       products.map((product) => ({
@@ -236,10 +246,17 @@ const Cart = ({ location }) => {
   }
 
   async function updateGuestCart() {
-    gcUpdate();
+    gcUpdate(products);
 
     try {
       const data = await fetchGuestCart(gc.items);
+      const newProducts = getMappedData(data.deliveryGroups);
+      if (beforeCountProducts.length !== newProducts.length) {
+        alert('상품의 재고가 충분치 않습니다.');
+        gcUpdate(beforeCountProducts);
+        window.location.reload();
+        return;
+      }
       mapData(data);
     } catch (err) {
       console.error(err);
@@ -281,7 +298,7 @@ const Cart = ({ location }) => {
     init();
   }
 
-  function gcUpdate() {
+  function gcUpdate (products) {
     if (!products.length) {
       throw new Error('products state is empty array');
     }
@@ -300,15 +317,23 @@ const Cart = ({ location }) => {
     }));
   }
 
-  function mapData(responseData) {
-    const { deliveryGroups, price } = responseData;
-
-    if (!deliveryGroups?.length) {
+  function mapData (responseData) {
+    if (!responseData?.deliveryGroups?.length) {
       reset();
       return;
     }
+    const result = getMappedData(responseData.deliveryGroups);
+    const { price } = responseData;
+    setProducts(result);
+    setAmount(price);
+  }
 
-    const result = deliveryGroups.flatMap((delivery) =>
+  function getMappedData (deliveryGroups) {
+    if (!deliveryGroups?.length) {
+      return [];
+    }
+
+    return deliveryGroups.flatMap((delivery) =>
       delivery.orderProducts.flatMap((productGroup) =>
         productGroup.orderProductOptions.flatMap((product) => {
           // debug pores
@@ -329,12 +354,9 @@ const Cart = ({ location }) => {
         }),
       ),
     );
-
-    setProducts(result);
-    setAmount(price);
   }
 
-  function reset() {
+  function reset () {
     setProducts([]);
     setAmount(null);
   }
@@ -363,6 +385,7 @@ const Cart = ({ location }) => {
                     <ProductList
                       products={products}
                       setProducts={setProducts}
+                      setBeforeCountProducts={setBeforeCountProducts}
                       deleteItem={deleteItem}
                       checkedIndexes={checkedIndexes}
                       setCheckedIndexes={setCheckedIndexes}

--- a/src/pages/order/Cart.js
+++ b/src/pages/order/Cart.js
@@ -112,7 +112,6 @@ const Cart = ({ location }) => {
       fetchGuestCart(body)
         .then((data) => {
         mapData(data);
-        console.log(data);
         checkGuestCartMissingProduct(getMappedData(data.deliveryGroups),
           gc.items);
         gc.fetch();

--- a/src/pages/order/Cart.js
+++ b/src/pages/order/Cart.js
@@ -111,14 +111,25 @@ const Cart = ({ location }) => {
       const body = getGuestCartRequest(gc.items);
       fetchGuestCart(body)
         .then((data) => {
-          mapData(data);
-          gc.fetch();
-          setCartCount(headerDispatch, gc.items.length);
-        })
-        .catch(console.error)
-        .finally(() => setWait(false));
+        mapData(data);
+        console.log(data);
+        checkGuestCartMissingProduct(getMappedData(data.deliveryGroups),
+          gc.items);
+        gc.fetch();
+        setCartCount(headerDispatch, gc.items.length);
+      }).catch(console.error).finally(() => setWait(false));
     }
   };
+
+  function checkGuestCartMissingProduct (
+    availableProducts, guestCartStorageItems) {
+    if (guestCartStorageItems.length > availableProducts.length) {
+      console.log(availableProducts);
+      alert('구매 불가한 상품이 포함되어있어 제거 되었습니다.');
+      gcUpdate(availableProducts);
+      location.reload();
+    }
+  }
 
   const goOrder = async () => {
     try {
@@ -127,7 +138,8 @@ const Cart = ({ location }) => {
         deleteGuestCart(checkedIndexes);
       }
       history.push(`/order/sheet?orderSheetNo=${orderSheetNo}`);
-    } catch (err) {
+    }
+    catch (err) {
       console.error(err);
     }
   };
@@ -299,9 +311,6 @@ const Cart = ({ location }) => {
   }
 
   function gcUpdate (products) {
-    if (!products.length) {
-      throw new Error('products state is empty array');
-    }
     const data = getGuestCartRequest(products);
     gc.cover(data);
   }


### PR DESCRIPTION
본디 cart API에서는 구매가능한 상품을 `deliveryGroups`, 불가한 상품을 `invalidProducts`로 응답을 내려준다.

`invalidProducts`를 따로 주는 이유는 **구매불가한 상품 데이터를 알려주어** 재고 부족들 문제로 인해 해당 상품을 구매할 수 없음을 사용자에게 알려주기 위함.

헌데 현재 스팩에서는 `invalidProducts`를 장바구니에 따로 표기하고 있지 않음.

### 때문에 비회원 카트에서 아래와 같은 문제가 발생한다. 
1. 5개 구매가능한 상품을 6개 장바구니에 담은 뒤 장바구니 진입
 : 해당 상품이 장바구니에 표시 안됨
2. 5개 구매가능한 상품의 수량 변경할 시
 : 해당 상품이 장바구니에 표시 안됨

### 이 문제를 방지하기 위하여 아래와 같이 수정함.
1. 5개 구매가능한 상품을 6개 장바구니에 담은 뒤 장바구니 진입
 : '구매 불가한 상품이 포함되어있어 제거 되었습니다.' 메시지 표출 후 비회원 카트에서 제거
2. 5개 구매가능한 상품의 수량 6개로 변경할 시
 : '상품의 재고가 충분치 않습니다.' 메시지 표출 후 수량 변경 이전 수량으로 되돌림


