### PR TITLE
이전 이용약관 버튼 클릭 시 에러 메시지 노출

### DIFF
--- a/src/hooks/useTerms.js
+++ b/src/hooks/useTerms.js
@@ -72,7 +72,7 @@ const useTerms = (termsTypes) => {
 
         if (prevEnforcementDate === '2018-04-16') {
             window.openWindow(
-                'https://store.sony.co.kr/handler/Common-PageView?pageName=jsp/footer/CF-termsTransfer.jsp ',
+                'https://image.sony.co.kr/newStore/html/terms_prev.html',
             );
             return;
         }
@@ -92,7 +92,7 @@ const useTerms = (termsTypes) => {
 };
 
 useTerms.propTypes = {
-    termsTypes: PropTypes.oneOf(['USE', 'PI_PROCESS', 'USE']),
+    termsTypes: PropTypes.oneOf(['USE', 'PI_PROCESS']),
 };
 
 export { useTerms };

--- a/src/pages/footer/terms.js
+++ b/src/pages/footer/terms.js
@@ -1,4 +1,4 @@
-import { React, useEffect, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import dayjs from 'dayjs';
 
 import SEO from 'components/SEO';

--- a/src/pages/footer/terms.js
+++ b/src/pages/footer/terms.js
@@ -1,7 +1,7 @@
 import { React, useEffect, useMemo } from 'react';
 import dayjs from 'dayjs';
 
-import SEOHelmet from 'components/SEOHelmet';
+import SEO from 'components/SEO';
 import Articles from 'components/support/Articles';
 import { articles } from 'const/support';
 import { useTerms } from 'hooks/useTerms';
@@ -33,7 +33,8 @@ export default function Terms() {
 
     return (
         <>
-            <SEOHelmet title={'소니스토어 이용약관'} />
+            <SEO data={{ title: '소니스토어 이용약관' }} />
+
             <div className='contents'>
                 <div className='container'>
                     <div className='content'>


### PR DESCRIPTION
- 이전 이용약관 버튼 클릭 시 에러 메시지 노출(65)


## TODO

 @Geewon-Jung 
 이용약관 관련 코드를 보면  '2018-04-16'이라는 날짜에 맞춰 로직이 돌아가고 있는데
 현재 개발서버에서는 prevEnforcementDate날짜가 2021-09-16으로 넘어오기 때문에 동작하지 않습니다.
 운영 서버 반영시 해당 날짜 확인 후 배포 부탁드립니다.
 (해당 코드는 `src/hooks/supports.js` 의 함수를 가져와서 사용한 부분이기 때문에 코드의 변경은 없습니다.)
