### PR TITLE
상품섹션이 롤링되는데, 롤링 사이클이 끝나면 깜빡이는 현상

### DIFF
--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -271,7 +271,7 @@
         span {
           display: block;
           opacity: 0;
-          transition: opacity .2s; // easeOutSine;
+          //transition: opacity .2s; // easeOutSine;
         }
 
         &__copy {


### PR DESCRIPTION
 - 상품섹션이 롤링되는데, 롤링 사이클이 끝나면 깜빡이는 현상 - 1
   - css에서 transition 때문에 충돌이 생기는 것으로 파악되어 해당 css를 삭제하였습니다. 제가 확인하기로는 아직 다른 부분에 영향이 없는 것으로 파악되지만 개발서버 반영하실 때 꼭 확인 부탁드립니다.