### PR TITLE
기획전 기간 노출 방식 변경 요청 - 44p

### DIFF
--- a/src/components/event/Top.js
+++ b/src/components/event/Top.js
@@ -9,7 +9,6 @@ import SwiperCore, {
     Scrollbar,
 } from 'swiper/core';
 import styled from 'styled-components';
-import dayjs from 'dayjs';
 
 import { loadBanner } from 'api/display';
 import { useMediaQuery } from 'hooks';
@@ -67,17 +66,7 @@ const EventTop = () => {
                             dangerouslySetInnerHTML={{
                                 __html: banner.description,
                             }}
-                        ></p>
-                        <p
-                            className='event_duration'
-                            style={{ color: banner.nameColor }}
-                        >
-                            {`${dayjs(banner.displayStartYmdt).format(
-                                'YYYY-MM-DD',
-                            )} ~ ${dayjs(banner.displayEndYmdt).format(
-                                'YYYY-MM-DD',
-                            )}`}
-                        </p>
+                        />
                         <div className='btn_article'>
                             <DetailLink
                                 to={banner.landingUrl}

--- a/src/components/recommend/RecommendEventBanners.js
+++ b/src/components/recommend/RecommendEventBanners.js
@@ -71,19 +71,6 @@ const RecommendEventBanners = ({ eventBanners }) => {
                                                 ),
                                             }}
                                         />
-                                        <p className='event_duration'>
-                                            {`${formatDate(
-                                                banners[0].displayStartYmdt,
-                                            )} ~ ${
-                                                banners[0].displayPeriodType ===
-                                                'PERIOD'
-                                                    ? formatDate(
-                                                          banners[0]
-                                                              .displayEndYmdt,
-                                                      )
-                                                    : '재고 소진 시'
-                                            }`}
-                                        </p>
                                     </div>
                                 </Link>
                             </div>


### PR DESCRIPTION
 - 소니스토어 추천 제품 > 하단 이벤트 리스트 배너 노출기간 비노출 처리
 - 기획전 > 기획전 롤링 배너 노출 기간 비노출 처리, `/` -> `<br>` 태그로 변경
   - 자세히보기 버튼과 간격은 적당한 것으로 보임